### PR TITLE
fix cpython version regex for download url

### DIFF
--- a/pythonz/installer/pythoninstaller.py
+++ b/pythonz/installer/pythoninstaller.py
@@ -116,7 +116,7 @@ class Installer(object):
 
 
 class CPythonInstaller(Installer):
-    version_re = re.compile(r'(\d\.\d(\.\d+)?)(.*)')
+    version_re = re.compile(r'(\d\.\d+(\.\d+)?)(.*)')
     supported_versions = versions['cpython']
 
     def __init__(self, version, options):


### PR DESCRIPTION
Still someone besides me using that? :thinking: 

----

to keep two digit minor versions like 3.10.4 working.

Before:

$ pew install 3.10.4
WARNING: Unsupported Python version: `3.10.4`, trying with the following URL anyway: http://www.python.org/ftp/python/3.1/Python-3.10.4.tgz
...
urllib.error.HTTPError: HTTP Error 404: Not Found

Now:

$ pew install 3.10.4
get_version_url(<class 'pythonz.installer.pythoninstaller.CPythonInstaller'>, 3.10.4):
WARNING: Unsupported Python version: `3.10.4`, trying with the following URL anyway: http://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz
Downloading Python-3.10.4.tgz as /home/lb/.pythonz/dists/Python-3.10.4.tgz
...